### PR TITLE
feat: Reorganize and add module to examples

### DIFF
--- a/docs/developer_guide/examples.md
+++ b/docs/developer_guide/examples.md
@@ -1,11 +1,22 @@
 ---
-title: Example deployments
+title: Examples
 ---
 
-# Example Deployments
+# Examples
 
-These repositories describe example deployments for Condenser.
+## Modules
 
-## [UCL-ARC/terraform-harvester-vm-demo](https://github.com/UCL-ARC/terraform-harvester-vm-demo)
+These repositories contain [modules](https://developer.hashicorp.com/terraform/language/modules) that
+have been developed for use in deployments on Condenser.
+
+### [UCL-ARC/terraform-harvester-modules](https://github.com/UCL-ARC/terraform-harvester-modules)
+
+This repository contains several useful modules for deploying virtual machines and k3s-based kubernetes clusters.
+
+## Deployments
+
+These repositories describe complete deployments for Condenser.
+
+### [UCL-ARC/terraform-harvester-vm-demo](https://github.com/UCL-ARC/terraform-harvester-vm-demo)
 
 A basic VM configured for SSH access.


### PR DESCRIPTION
* Reorganizes the Examples page into modules and complete deployments.
* Links to an example repository for modules developed by the ARC devops subgroup.