### PR TITLE
Update links to Harvester docs

### DIFF
--- a/docs/documentation/deploying_resources/deploying_rancher.md
+++ b/docs/documentation/deploying_resources/deploying_rancher.md
@@ -4,7 +4,7 @@ title: Deploying with the Rancher GUI
 
 # Deploying with the Rancher GUI
 
-Condenser consists of several [Harvester](https://docs.harvesterhci.io/v1.2/) clusters.
+Condenser consists of several [Harvester](https://docs.harvesterhci.io/) clusters.
 Harvester runs on [Kubernetes](https://kubernetes.io/); therefore each cluster is
 a specialized Kubernetes cluster. [Rancher](https://www.rancher.com/) is used to
 control access to the clusters, and provides a GUI which is accessible within the

--- a/docs/documentation/index.md
+++ b/docs/documentation/index.md
@@ -40,6 +40,6 @@ Please refer to the appropriate documentation. Some starting points are listed b
 
 ### Cloud infrastructure
 
-- [Harvester](https://docs.harvesterhci.io/v1.2/)
+- [Harvester](https://docs.harvesterhci.io/)
 - [Cloudinit](https://cloudinit.readthedocs.io/en/latest/)
 - [Kubernetes](https://kubernetes.io/docs/home/)

--- a/docs/documentation/ssh_access.md
+++ b/docs/documentation/ssh_access.md
@@ -4,7 +4,7 @@ title: Configuring a VM for SSH access
 
 # Configuring a VM for SSH access
 
-To be accessible by SSH, a VM needs to be configured with a [VLAN Network](https://docs.harvesterhci.io/v1.2/networking/harvester-network/)
+To be accessible by SSH, a VM needs to be configured with a [VLAN Network](https://docs.harvesterhci.io/latest/networking/harvester-network/)
 and the SSH public key data needs to be provided via [cloudinit](https://cloudinit.readthedocs.io/en/latest/reference/modules.html#ssh).
 We have documentation demonstrating this for [Terraform deployments](./deploying_resources/deploying_terraform.md/#configure-the-vm-for-ssh-access)
 and for the [Rancher GUI](./deploying_resources/deploying_rancher.md).


### PR DESCRIPTION
* We now have an update schedule, so links to the Harvester docs can point to the latest documentation as we should always be within one minor version of their latest.

#minor
